### PR TITLE
Fixing command on docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     working_dir: /usr/src/app
     ports:
       - "3000:3000"
-    command: "lein ring server"
+    command: "lein ring server-headless"
     depends_on:
       - postgres
   postgres:


### PR DESCRIPTION
When try to start a **lein ring server**, the environment require a web browser and appers this error: 
![necessita-web-browser](https://user-images.githubusercontent.com/5812650/65929745-a2306600-e3d9-11e9-8b58-6358dc4efddf.PNG)

To fix that problem, it's necessary to use:

> lein ring server-headless  
 